### PR TITLE
Fix absence of username attribute in ldap search result dict.

### DIFF
--- a/lib/casino/ldap_authenticator.rb
+++ b/lib/casino/ldap_authenticator.rb
@@ -43,7 +43,8 @@ class CASino::LDAPAuthenticator
     end
     @user_plain = @ldap.bind_as(:base => @options[:base], :size => 1, :password => @password, :filter => user_filter)
     if @user_plain != false
-      @user_plain = @ldap.search(:base => @options[:base], :filter => user_filter, :attributes => @options[:extra_attributes].values)
+      include_attributes = @options[:extra_attributes].values + [username_attribute]
+      @user_plain = @ldap.search(:base => @options[:base], :filter => user_filter, :attributes => include_attributes)
       if @user_plain.is_a?(Array)
         @user_plain = @user_plain.first
       end


### PR DESCRIPTION
The last commit in this file broke creation of new users.
The result dict of the LDAP search did not include the username attribute, only the extra attirbutes. My PR fixes this.
