### PR TITLE
support for multiple ldap hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ To use the LDAP authenticator, configure it in your cas.yml:
         options:
           host: "localhost"
           port: 636
+          # hosts: [['localhost', 636], ['otherhost', 636]]
           base: "ou=people,dc=example,dc=com"
           username_attribute: "uid"
           encryption: "simple_tls"

--- a/lib/casino/ldap_authenticator.rb
+++ b/lib/casino/ldap_authenticator.rb
@@ -23,8 +23,12 @@ class CASino::LDAPAuthenticator
   private
   def connect_to_ldap
     Net::LDAP.new.tap do |ldap|
-      ldap.host = @options[:host]
-      ldap.port = @options[:port]
+      if @options.key? :hosts
+        ldap.hosts = @options[:hosts]
+      else
+        ldap.host = @options[:host]
+        ldap.port = @options[:port]
+      end
       if @options[:encryption]
         ldap.encryption(@options[:encryption].to_sym)
       end

--- a/spec/casino/ldap_authenticator_spec.rb
+++ b/spec/casino/ldap_authenticator_spec.rb
@@ -61,10 +61,28 @@ describe CASino::LDAPAuthenticator do
     let(:extra_attributes) { ['mail', :displayname, 'memberof'] }
 
     it 'does the connection setup' do
+      connection.should_not_receive(:hosts=)
       connection.should_receive(:host=).with(options[:host])
       connection.should_receive(:port=).with(options[:port])
       connection.should_receive(:encryption).with(:"#{options[:encryption]}")
       subject.validate(username, password)
+    end
+
+    describe 'with :hosts option' do
+      let(:options) { {
+          :hosts => [['localhost', 12445], ['otherhost', 98765]],
+          :base => 'dc=users,dc=example.com',
+          :encryption => 'simple_tls',
+          :username_attribute => 'uid',
+          :extra_attributes => { :email => 'mail', :fullname => :displayname, :memberof => 'memberof'}
+        } }
+      it 'does the connection setup' do
+        connection.should_not_receive(:host=)
+        connection.should_not_receive(:port=)
+        connection.should_receive(:hosts=).with(options[:hosts])
+        connection.should_receive(:encryption).with(:"#{options[:encryption]}")
+      subject.validate(username, password)
+      end
     end
 
     it 'calls the #bind_as method on the LDAP connection' do


### PR DESCRIPTION
`Net::LDAP` supports a `:hosts` option to supply a list of host / port pairs when creating a new connection. Some of our clients have a setup that requires our CASino installation to work with more than a single LDAP host.
